### PR TITLE
Collapsing from full screen controller animation fixes

### DIFF
--- a/ios-app-store/Controllers/Today/TodayController.swift
+++ b/ios-app-store/Controllers/Today/TodayController.swift
@@ -67,11 +67,8 @@ class TodayController: BaseListController, UICollectionViewDelegateFlowLayout, U
     
     @objc func handleAppFullscreenDismissal() {
         UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0.7, options: .curveEaseOut, animations: {
-            
             self.blurVisualEffectView.alpha = 0
             self.appFullscreenController.view.transform = .identity
-            
-            self.appFullscreenController.tableView.contentOffset = .zero
             
             guard let startingFrame = self.startingFrame else { return }
             
@@ -81,6 +78,8 @@ class TodayController: BaseListController, UICollectionViewDelegateFlowLayout, U
             self.anchoredConstraints?.height?.constant = startingFrame.height
             
             self.view.layoutIfNeeded()
+            
+            self.appFullscreenController.tableView.contentOffset = .zero
             
             //Replaced old transform behavior because its not working anymore on iOS 13
             //https://stackoverflow.com/questions/58199604/cgaffinetransform-translation-doesnt-work-on-tabbar-after-update-to-xcode-11
@@ -97,6 +96,8 @@ class TodayController: BaseListController, UICollectionViewDelegateFlowLayout, U
         }, completion: { _ in
             self.appFullscreenController.view.removeFromSuperview()
             self.appFullscreenController.removeFromParent()
+//            self.appFullscreenController.tableView.bounces = true
+//            self.appFullscreenController.tableView.bouncesZoom = true
             self.collectionView.isUserInteractionEnabled = true
         })
     }

--- a/ios-app-store/Controllers/Today/TodayController.swift
+++ b/ios-app-store/Controllers/Today/TodayController.swift
@@ -66,7 +66,7 @@ class TodayController: BaseListController, UICollectionViewDelegateFlowLayout, U
     var startingFrame: CGRect?
     
     @objc func handleAppFullscreenDismissal() {
-        UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0.7, options: .curveEaseOut, animations: {
+        UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0.7, options: .curveEaseOut, animations: {
             self.blurVisualEffectView.alpha = 0
             self.appFullscreenController.view.transform = .identity
             


### PR DESCRIPTION
First one places scrolling to top after main controller layoutIfNeeded. Before that layoutIfNeeded was messing with setting contentOffset and canceling that change.

Second one disables bouncing animation cause it was causing artifacts when you could see white bacground behind image during bouncing. Also it matches app stor behavior now. 

As I was intending to borrow only this animation behaviors I will probably stop committing now. Only if some other visual problems will appear. 

Many thanks for the code!